### PR TITLE
Implement Firebase and AngularFire CDN

### DIFF
--- a/libraries/AngularFire.sublime-snippet
+++ b/libraries/AngularFire.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+	<content><![CDATA[<script src="//cdn.firebase.com/libs/angularfire/${1:1.1.1}/angularfire.min.js"></script>$0]]></content>
+	<tabTrigger>cdn</tabTrigger>
+	<description>AngularFire : AngularJS + Firebase</description>
+	<scope>source.php,text.html, source.jade</scope>
+</snippet>

--- a/libraries/Firebase.sublime-snippet
+++ b/libraries/Firebase.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+	<content><![CDATA[<script src="//cdn.firebase.com/js/client/${1:2.2.7}/firebase.js"></script>$0]]></content>
+	<tabTrigger>cdn</tabTrigger>
+	<description>Firebase</description>
+	<scope>source.php,text.html, source.jade</scope>
+</snippet>


### PR DESCRIPTION
Allows user to grab `Firebase` and `AngularFire` javascript through `cdn.firebase.com` host.

URLs comes from documentation.