### PR TITLE
Add CDN for Handlebars runtime.

### DIFF
--- a/libraries/Handlebars-runtime.sublime-snippet
+++ b/libraries/Handlebars-runtime.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+  <content><![CDATA[<script src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.10/handlebars.runtime.min.js"></script>]]></content>
+  <tabTrigger>cdn</tabTrigger>
+  <description>Handlerbars Runtime</description>
+  <scope>source.php,text.html,source.jade</scope>
+</snippet>


### PR DESCRIPTION
Add CDN for the Handlebars runtime for use when pre-compiling templates. Instead of using the whole library, we just use the runtime when templates have been pre-compiled.

From Handlebars website:

>In addition to reducing the download size, eliminating client-side compilation will significantly speed up boot time, as compilation is the most expensive part of Handlebars.